### PR TITLE
Update data annotation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To create the annotations, we use [vLLM](https://github.com/vllm-project/vllm) a
 The annotation script assumes the dataset will be annotated in different chunks using the `n-annotation-chunks` argument. This allows for a process that can be parallelized depending on the availability of resources, and is robust to restarts/preemption. To run with a single chunk (i.e., to process the entire dataset), and annotate with the default prompt template and task specification, run the following command.
 
 ```
-python -m scripts.annotate_pairs_dataset.py --directory motif_dataset \
+python -m scripts.annotate_pairs_dataset --directory motif_dataset \
                                  --prompt-version default --goal-key defaultgoal \
                                  --n-annotation-chunks 1 --chunk-number 0 \
                                  --llm-size 70 --num-gpus 8


### PR DESCRIPTION
Using `.py` extension while running with `-m` flag causes the following problem: 

> Error while finding module specification for `scripts.annotate_pairs_dataset.py` (ModuleNotFoundError: _path_ attribute not found on `scripts.annotate_pairs_dataset` while trying to find `scripts.annotate_pairs_dataset.py`). Try using `scripts.annotate_pairs_dataset` instead of `scripts.annotate_pairs_dataset.py` as the module name.

So, `scripts.annotate_pairs_dataset.py` is replaced by `scripts.annotate_pairs_dataset`.